### PR TITLE
Option to apply DeepCache only in 2nd pass

### DIFF
--- a/scripts/deepcache_script.py
+++ b/scripts/deepcache_script.py
@@ -23,7 +23,7 @@ class ScriptDeepCache(scripts.Script):
     def process_batch(self, p:processing.StableDiffusionProcessing, *args, **kwargs):
         print("DeepCache process")
         self.detach_deepcache()
-        if shared.opts.deepcache_enable:
+        if shared.opts.deepcache_enable_pass == "both passes":
             self.configure_deepcache(self.get_deepcache_params(p.steps))
 
     def before_hr(self, p:processing.StableDiffusionProcessing, *args):
@@ -32,7 +32,7 @@ class ScriptDeepCache(scripts.Script):
             self.session.enumerated_timestep["value"] = -1 # reset enumerated timestep
         if not shared.opts.deepcache_hr_reuse:
             self.detach_deepcache()
-        if shared.opts.deepcache_enable:
+        if shared.opts.deepcache_enable_pass != "disable":
             hr_steps = getattr(p, 'hr_second_pass_steps', 0) or p.steps
             enable_step = int(shared.opts.deepcache_cache_enable_step_percentage_hr * hr_steps)
             self.configure_deepcache(self.get_deepcache_params(getattr(p, 'hr_second_pass_steps', 0) or p.steps, enable_step_at = enable_step)) # use second pass steps if available
@@ -63,7 +63,7 @@ def on_ui_settings():
         "deepcache_explanation": shared.OptionHTML("""
     <a href='https://github.com/horseee/DeepCache'>DeepCache</a> optimizes by caching the results of mid-blocks, which is known for high level features, and reusing them in the next forward pass.
     """),
-        "deepcache_enable": shared.OptionInfo(False, "Enable DeepCache").info("noticeable change in details of the generated picture"),
+        "deepcache_enable_pass": shared.OptionInfo("disable", "Enable DeepCache for", gr.Radio, {"choices": ["disable", "second pass", "both passes"]}, infotext="Pass to DeepCache").info("noticeable change in details of the generated picture"),
         "deepcache_cache_resnet_level": shared.OptionInfo(0, "Cache Resnet level", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}).info("Deeper = fewer layers cached"),
         "deepcache_cache_enable_step_percentage": shared.OptionInfo(0.4, "Deepcaches is enabled after the step percentage", gr.Slider, {"minimum": 0, "maximum": 1}).info("Percentage of initial steps to disable deepcache"),
         "deepcache_full_run_step_rate": shared.OptionInfo(5, "Refreshes caches when step is divisible by number", gr.Slider, {"minimum": 0, "maximum": 1000, "step": 1}).info("5 = refresh caches every 5 steps"),

--- a/scripts/deepcache_script.py
+++ b/scripts/deepcache_script.py
@@ -63,7 +63,7 @@ def on_ui_settings():
         "deepcache_explanation": shared.OptionHTML("""
     <a href='https://github.com/horseee/DeepCache'>DeepCache</a> optimizes by caching the results of mid-blocks, which is known for high level features, and reusing them in the next forward pass.
     """),
-        "deepcache_enable_pass": shared.OptionInfo("disable", "Enable DeepCache for", gr.Radio, {"choices": ["disable", "second pass", "both passes"]}, infotext="Pass to DeepCache").info("noticeable change in details of the generated picture"),
+        "deepcache_enable_pass": shared.OptionInfo("disable", "Enable DeepCache for", gr.Radio, {"choices": ["disable", "second pass", "both passes"]}, infotext="DeepCache pass").info("noticeable change in details of the generated picture"),
         "deepcache_cache_resnet_level": shared.OptionInfo(0, "Cache Resnet level", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}).info("Deeper = fewer layers cached"),
         "deepcache_cache_enable_step_percentage": shared.OptionInfo(0.4, "Deepcaches is enabled after the step percentage", gr.Slider, {"minimum": 0, "maximum": 1}).info("Percentage of initial steps to disable deepcache"),
         "deepcache_full_run_step_rate": shared.OptionInfo(5, "Refreshes caches when step is divisible by number", gr.Slider, {"minimum": 0, "maximum": 1000, "step": 1}).info("5 = refresh caches every 5 steps"),

--- a/scripts/deepcache_script.py
+++ b/scripts/deepcache_script.py
@@ -21,13 +21,11 @@ class ScriptDeepCache(scripts.Script):
         )
 
     def process_batch(self, p:processing.StableDiffusionProcessing, *args, **kwargs):
-        print("DeepCache process")
         self.detach_deepcache()
         if shared.opts.deepcache_enable_pass == "both passes":
             self.configure_deepcache(self.get_deepcache_params(p.steps))
 
     def before_hr(self, p:processing.StableDiffusionProcessing, *args):
-        print("DeepCache before_hr")
         if self.session is not None:
             self.session.enumerated_timestep["value"] = -1 # reset enumerated timestep
         if not shared.opts.deepcache_hr_reuse:
@@ -38,7 +36,6 @@ class ScriptDeepCache(scripts.Script):
             self.configure_deepcache(self.get_deepcache_params(getattr(p, 'hr_second_pass_steps', 0) or p.steps, enable_step_at = enable_step)) # use second pass steps if available
 
     def postprocess_batch(self, p:processing.StableDiffusionProcessing, *args, **kwargs):
-        print("DeepCache postprocess")
         self.detach_deepcache()
 
     def configure_deepcache(self, params:DeepCacheParams):
@@ -50,10 +47,8 @@ class ScriptDeepCache(scripts.Script):
         )
 
     def detach_deepcache(self):
-        print("Detaching DeepCache")
         if self.session is None:
             return
-        self.session.report()
         self.session.detach()
         self.session = None
 

--- a/scripts/deepcache_xyz.py
+++ b/scripts/deepcache_xyz.py
@@ -47,9 +47,17 @@ def float_applier(value_name:str, min_range:float = -1, max_range:float = -1):
         opts.data[value_name] = float(x)
     return apply_float
 
+def field_applier(value_name: str):
+    def validate(value_name:str, value:str):
+        assert isinstance(value, str), f"Value {value} for {value_name} must be string"
+    def apply_field(p, x, xs):
+        validate(value_name, x)
+        opts.data[value_name] = x
+    return apply_field
+
 def add_axis_options():
     extra_axis_options = [
-        xyz_grid.AxisOption("[DeepCache] Enabled", str, bool_applier("deepcache_enable"), choices=xyz_grid.boolean_choice(reverse=True)),
+        xyz_grid.AxisOption("[DeepCache] Enable DeepCache for", str, field_applier("deepcache_enable_pass"), choices=lambda: ["disable", "second pass", "both passes"]),
         xyz_grid.AxisOption("[DeepCache] Cache Resnet level", int, int_applier("deepcache_cache_resnet_level", 0, 10)),
         xyz_grid.AxisOption("[DeepCache] Cache Disable initial step percentage", float, float_applier("deepcache_cache_enable_step_percentage", 0, 1)),
         xyz_grid.AxisOption("[DeepCache] Cache Refresh Rate", int, int_applier("deepcache_full_run_step_rate", 0, 1000)),


### PR DESCRIPTION
DeepCache를 hires(2nd pass)에만 적용하는 건 어떨까하여 수정하였습니다.
hires에만 적용 시 속도 개선은 적어지지만, 원본(1st pass)에 더 가까운 최종 결과물을 얻을 수 있는 장점이 있습니다.

활성화 체크 박스를 ['disable', '2nd pass', 'both passes']라디오 버튼으로 변경하여 적용하였는데,
Settings in UI에서 Txt2Img에 빼서 사용하거나 x/y/z/plot으로 테이블을 만들 때 유용하기 때문입니다.
활성화 명칭은 WebUI의 refiner 설정을 참고하였습니다.